### PR TITLE
Make index single-line based and integrity check index

### DIFF
--- a/data/atom-sourcenode_pub_dolbunova_fcopttsocftnssir_2021.json
+++ b/data/atom-sourcenode_pub_dolbunova_fcopttsocftnssir_2021.json
@@ -8,7 +8,7 @@
     },
     {
       "SourceNode": {
-        "Included": [
+        "Excluded": [
           {
             "Bibliographic": {
               "Author": {
@@ -22,43 +22,13 @@
               "DataAvailability": "NotAttachedToSource"
             }
           },
+          "NotArcticRegion",
           {
-            "Stalled": [
-              [
-                {
-                  "item": "source-primary-or-secondary"
-                }
-              ],
-              {
-                "item": "exposure"
-              },
-              {
-                "item": "accidently included, meant to exclude for out of Arctic region, but misread Russian map. Please exclude from further analysis"
-              }
-            ]
+            "item": "Below Arctic in Russia"
           }
         ]
       }
     }
   ],
-  [
-    [
-      {
-        "FriendlyKey": [
-          "sourcenode",
-          "pub_dolbunova_fcopttsocftnssir_2021"
-        ]
-      },
-      {
-        "UUID": [
-          "individualtimelinenode",
-          "e1bf3347-96f1-45a5-8b7f-0a47be55044e"
-        ]
-      },
-      1,
-      {
-        "Source": "HasTemporalExtent"
-      }
-    ]
-  ]
+  []
 ]


### PR DESCRIPTION
Allows easier merging of pull requests, as each index item is a single line.

Also error checked the node index and corrected pretty names on some taxa, which had been corrupted in a previous pull request.